### PR TITLE
Removed ${camel.version} that was failing the build

### DIFF
--- a/catalyst-service/src/main/resources/application.yml
+++ b/catalyst-service/src/main/resources/application.yml
@@ -420,7 +420,6 @@ initializr:
           artifactId: camel-grpc-starter
           dependsOn:
           - camel
-          version: ${camel.version}
         - name: gRPC All
           id: grpc-all
           description: The gRPC core public API


### PR DESCRIPTION
Removed ${camel.version} that was failing the build as it will be inherited from BOM